### PR TITLE
Expose struct attributes.

### DIFF
--- a/expand/expand.go
+++ b/expand/expand.go
@@ -37,50 +37,50 @@ const (
 )
 
 type ExpandOptions struct {
-    languages []string
-    addressComponents uint16
-    latinAscii bool
-    transliterate bool
-    stripAccents bool
-    decompose bool
-    lowercase bool
-    trimString bool
-    replaceWordHyphens bool
-    deleteWordHyphens bool
-    replaceNumericHyphens bool
-    deleteNumericHyphens bool
-    splitAlphaFromNumeric bool
-    deleteFinalPeriods bool
-    deleteAcronymPeriods bool
-    dropEnglishPossessives bool
-    deleteApostrophes bool
-    expandNumex bool
-    romanNumerals bool
+    Languages []string
+    AddressComponents uint16
+    LatinAscii bool
+    Transliterate bool
+    StripAccents bool
+    Decompose bool
+    Lowercase bool
+    TrimString bool
+    ReplaceWordHyphens bool
+    DeleteWordHyphens bool
+    ReplaceNumericHyphens bool
+    DeleteNumericHyphens bool
+    SplitAlphaFromNumeric bool
+    DeleteFinalPeriods bool
+    DeleteAcronymPeriods bool
+    DropEnglishPossessives bool
+    DeleteApostrophes bool
+    ExpandNumex bool
+    RomanNumerals bool
 }
 
 var cDefaultOptions = C.get_libpostal_default_options()
 
 func getDefaultExpansionOptions() ExpandOptions {
     return ExpandOptions{
-        languages: nil,
-        addressComponents: uint16(cDefaultOptions.address_components),
-        latinAscii: bool(cDefaultOptions.latin_ascii),
-        transliterate: bool(cDefaultOptions.transliterate),
-        stripAccents: bool(cDefaultOptions.strip_accents),
-        decompose: bool(cDefaultOptions.decompose),
-        lowercase: bool(cDefaultOptions.lowercase),
-        trimString: bool(cDefaultOptions.trim_string),
-        replaceWordHyphens: bool(cDefaultOptions.replace_word_hyphens),
-        deleteWordHyphens: bool(cDefaultOptions.delete_word_hyphens),
-        replaceNumericHyphens: bool(cDefaultOptions.replace_numeric_hyphens),
-        deleteNumericHyphens: bool(cDefaultOptions.delete_numeric_hyphens),
-        splitAlphaFromNumeric: bool(cDefaultOptions.split_alpha_from_numeric),
-        deleteFinalPeriods: bool(cDefaultOptions.delete_final_periods),
-        deleteAcronymPeriods: bool(cDefaultOptions.delete_acronym_periods),
-        dropEnglishPossessives: bool(cDefaultOptions.drop_english_possessives),
-        deleteApostrophes: bool(cDefaultOptions.delete_apostrophes),
-        expandNumex: bool(cDefaultOptions.expand_numex),
-        romanNumerals: bool(cDefaultOptions.roman_numerals),
+        Languages: nil,
+        AddressComponents: uint16(cDefaultOptions.address_components),
+        LatinAscii: bool(cDefaultOptions.latin_ascii),
+        Transliterate: bool(cDefaultOptions.transliterate),
+        StripAccents: bool(cDefaultOptions.strip_accents),
+        Decompose: bool(cDefaultOptions.decompose),
+        Lowercase: bool(cDefaultOptions.lowercase),
+        TrimString: bool(cDefaultOptions.trim_string),
+        ReplaceWordHyphens: bool(cDefaultOptions.replace_word_hyphens),
+        DeleteWordHyphens: bool(cDefaultOptions.delete_word_hyphens),
+        ReplaceNumericHyphens: bool(cDefaultOptions.replace_numeric_hyphens),
+        DeleteNumericHyphens: bool(cDefaultOptions.delete_numeric_hyphens),
+        SplitAlphaFromNumeric: bool(cDefaultOptions.split_alpha_from_numeric),
+        DeleteFinalPeriods: bool(cDefaultOptions.delete_final_periods),
+        DeleteAcronymPeriods: bool(cDefaultOptions.delete_acronym_periods),
+        DropEnglishPossessives: bool(cDefaultOptions.drop_english_possessives),
+        DeleteApostrophes: bool(cDefaultOptions.delete_apostrophes),
+        ExpandNumex: bool(cDefaultOptions.expand_numex),
+        RomanNumerals: bool(cDefaultOptions.roman_numerals),
     }
 }
 
@@ -94,42 +94,42 @@ func ExpandAddressOptions(address string, options ExpandOptions) []string {
     ptr_size := unsafe.Sizeof(char_ptr)
 
     cOptions := C.get_libpostal_default_options()
-    if options.languages != nil {
-        cLanguages := C.calloc(C.size_t(len(options.languages)), C.size_t(ptr_size))
+    if options.Languages != nil {
+        cLanguages := C.calloc(C.size_t(len(options.Languages)), C.size_t(ptr_size))
         cLanguagesPtr := (*[1<<30](*C.char))(unsafe.Pointer(cLanguages))
 
         defer C.free(unsafe.Pointer(cLanguages))
 
-        for i := 0; i < len(options.languages); i++ {
-            cLang := C.CString(options.languages[i])
+        for i := 0; i < len(options.Languages); i++ {
+            cLang := C.CString(options.Languages[i])
             defer C.free(unsafe.Pointer(cLang))
             cLanguagesPtr[i] = cLang
         }
 
         cOptions.languages = (**C.char)(cLanguages)
-        cOptions.num_languages = C.int(len(options.languages))
+        cOptions.num_languages = C.int(len(options.Languages))
     } else {
         cOptions.num_languages = 0
     }
 
-    cOptions.address_components = C.uint16_t(options.addressComponents)
-    cOptions.latin_ascii = C.bool(options.latinAscii)
-    cOptions.transliterate = C.bool(options.transliterate)
-    cOptions.strip_accents = C.bool(options.stripAccents)
-    cOptions.decompose = C.bool(options.decompose)
-    cOptions.lowercase = C.bool(options.lowercase)
-    cOptions.trim_string = C.bool(options.trimString)
-    cOptions.replace_word_hyphens = C.bool(options.replaceWordHyphens)
-    cOptions.delete_word_hyphens = C.bool(options.deleteWordHyphens)
-    cOptions.replace_numeric_hyphens = C.bool(options.replaceNumericHyphens)
-    cOptions.delete_numeric_hyphens = C.bool(options.deleteNumericHyphens)
-    cOptions.split_alpha_from_numeric = C.bool(options.splitAlphaFromNumeric)
-    cOptions.delete_final_periods = C.bool(options.deleteFinalPeriods)
-    cOptions.delete_acronym_periods = C.bool(options.deleteAcronymPeriods)
-    cOptions.drop_english_possessives = C.bool(options.dropEnglishPossessives)
-    cOptions.delete_apostrophes = C.bool(options.deleteApostrophes)
-    cOptions.expand_numex = C.bool(options.expandNumex)
-    cOptions.roman_numerals = C.bool(options.romanNumerals)
+    cOptions.address_components = C.uint16_t(options.AddressComponents)
+    cOptions.latin_ascii = C.bool(options.LatinAscii)
+    cOptions.transliterate = C.bool(options.Transliterate)
+    cOptions.strip_accents = C.bool(options.StripAccents)
+    cOptions.decompose = C.bool(options.Decompose)
+    cOptions.lowercase = C.bool(options.Lowercase)
+    cOptions.trim_string = C.bool(options.TrimString)
+    cOptions.replace_word_hyphens = C.bool(options.ReplaceWordHyphens)
+    cOptions.delete_word_hyphens = C.bool(options.DeleteWordHyphens)
+    cOptions.replace_numeric_hyphens = C.bool(options.ReplaceNumericHyphens)
+    cOptions.delete_numeric_hyphens = C.bool(options.DeleteNumericHyphens)
+    cOptions.split_alpha_from_numeric = C.bool(options.SplitAlphaFromNumeric)
+    cOptions.delete_final_periods = C.bool(options.DeleteFinalPeriods)
+    cOptions.delete_acronym_periods = C.bool(options.DeleteAcronymPeriods)
+    cOptions.drop_english_possessives = C.bool(options.DropEnglishPossessives)
+    cOptions.delete_apostrophes = C.bool(options.DeleteApostrophes)
+    cOptions.expand_numex = C.bool(options.ExpandNumex)
+    cOptions.roman_numerals = C.bool(options.RomanNumerals)
 
     var cNumExpansions = C.size_t(0)
 

--- a/expand/expand_test.go
+++ b/expand/expand_test.go
@@ -28,7 +28,7 @@ func TestEnglishExpansions(t *testing.T) {
     testExpansion(t, "123 Main St", "123 main street")
 
     englishOptions := getDefaultExpansionOptions()
-    englishOptions.languages = []string{"en"}
+    englishOptions.Languages = []string{"en"}
 
     testExpansionWithOptions(t, "30 West Twenty-sixth St Fl No. 7", "30 west 26th street floor number 7", englishOptions) 
     testExpansionWithOptions(t, "Thirty W 26th St Fl #7", "30 west 26th street floor number 7", englishOptions)
@@ -38,7 +38,7 @@ func TestEnglishExpansions(t *testing.T) {
 
 func TestMultilingualExpansions(t *testing.T) {
     multilingualOptions := getDefaultExpansionOptions()
-    multilingualOptions.languages = []string{"en", "fr", "de"}
+    multilingualOptions.Languages = []string{"en", "fr", "de"}
 
     testExpansionWithOptions(t, "st", "sankt", multilingualOptions)
     testExpansionWithOptions(t, "st", "saint", multilingualOptions)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -16,23 +16,23 @@ func init() {
 }
 
 type ParserOptions struct {
-    language string
-    country string
+    Language string
+    Country string
 }
 
 
 func getDefaultParserOptions() ParserOptions {
     return ParserOptions {
-        language: "",
-        country: "",
+        Language: "",
+        Country: "",
     }
 }
 
 var parserDefaultOptions = getDefaultParserOptions()
 
 type ParsedComponent struct {
-    component string
-    label string
+    Component string
+    Label string
 }
 
 func ParseAddressOptions(address string, options ParserOptions) []ParsedComponent {
@@ -43,15 +43,15 @@ func ParseAddressOptions(address string, options ParserOptions) []ParsedComponen
     //ptr_size := unsafe.Sizeof(b)
 
     cOptions := C.get_libpostal_address_parser_default_options()
-    if options.language != "" {
-        cLanguage := C.CString(options.language)
+    if options.Language != "" {
+        cLanguage := C.CString(options.Language)
         defer C.free(unsafe.Pointer(cLanguage))
 
         cOptions.language = cLanguage
     }
 
-    if options.country != "" {
-        cCountry := C.CString(options.country)
+    if options.Country != "" {
+        cCountry := C.CString(options.Country)
         defer C.free(unsafe.Pointer(cCountry))
 
         cOptions.country = cCountry
@@ -80,8 +80,8 @@ func ParseAddressOptions(address string, options ParserOptions) []ParsedComponen
     var i uint64
     for i = 0; i < numComponents; i++ {
         parsedComponents[i] = ParsedComponent{
-            component: C.GoString(cComponentsPtr[i]),
-            label: C.GoString(cLabelsPtr[i]),
+            Component: C.GoString(cComponentsPtr[i]),
+            Label: C.GoString(cLabelsPtr[i]),
         }
     }
 


### PR DESCRIPTION
Go requires that attributes be uppercased in order to be exposed outside the package. When they are lowercase, they're private, which works okay inside the package (e.g., in your tests), but not outside. I ran into this when trying to display `ParsedComponent`s as JSON: There was no way to get at the label or value!
