### PR TITLE
Support JSON marshaling and unmarshaling.

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -31,8 +31,8 @@ func getDefaultParserOptions() ParserOptions {
 var parserDefaultOptions = getDefaultParserOptions()
 
 type ParsedComponent struct {
-    Value string
-    Label string
+    Label string `json:"label"`
+    Value string `json:"value"`
 }
 
 func ParseAddressOptions(address string, options ParserOptions) []ParsedComponent {
@@ -80,8 +80,8 @@ func ParseAddressOptions(address string, options ParserOptions) []ParsedComponen
     var i uint64
     for i = 0; i < numComponents; i++ {
         parsedComponents[i] = ParsedComponent{
-            Value: C.GoString(cComponentsPtr[i]),
             Label: C.GoString(cLabelsPtr[i]),
+            Value: C.GoString(cComponentsPtr[i]),
         }
     }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,15 +1,35 @@
 package postal
 
 import (
+	"encoding/json"
     "reflect"
     "testing"
 )
 
-func testParse(t *testing.T, address string, expectedOutput []ParsedComponent) {
+func testParse(t *testing.T, address string, expectedOutput []ParsedComponent, expectedJSON string) {
     parsedComponents := ParseAddress(address)
 
     if len(parsedComponents) != len(expectedOutput) || !reflect.DeepEqual(parsedComponents, expectedOutput) {
-        t.Error("parsed != expected", parsedComponents, "!=", expectedOutput)
+        t.Error("parsed != expected: ", parsedComponents, "!=", expectedOutput)
+    }
+
+	// Test JSON marshaling.
+	marshaledJSON, err := json.Marshal(parsedComponents)
+	if err != nil {
+		t.Error("JSON.marshal error: " + err.Error())
+	}
+
+	if string(marshaledJSON) != expectedJSON {
+        t.Error("json != expected: ", string(marshaledJSON), "!=", expectedJSON)
+	}
+
+	// Test JSON unmarshaling.
+	var unmarshaledComponents []ParsedComponent
+	if err := json.Unmarshal(marshaledJSON, &unmarshaledComponents); err != nil {
+		t.Error("JSON.unmarshal error: " + err.Error())
+	}
+    if !reflect.DeepEqual(unmarshaledComponents, expectedOutput) {
+        t.Error("unmarshaled != expected: ", unmarshaledComponents, "!=", expectedOutput)
     }
 }
 
@@ -18,54 +38,58 @@ func TestParseUSAddress(t *testing.T) {
 
     testParse(t, "781 Franklin Ave Crown Heights Brooklyn NYC NY 11216 USA", 
               []ParsedComponent {
-                  {"781", "house_number"},
-                  {"franklin ave", "road"},
-                  {"crown heights", "suburb"},
-                  {"brooklyn", "city_district"},
-                  {"nyc", "city"},
-                  {"ny", "state"},
-                  {"11216", "postcode"},
-                  {"usa", "country"},
+                  {"house_number", "781"},
+                  {"road", "franklin ave"},
+                  {"suburb", "crown heights"},
+                  {"city_district", "brooklyn"},
+                  {"city", "nyc"},
+                  {"state", "ny"},
+                  {"postcode", "11216"},
+                  {"country", "usa"},
               },
+              `[{"label":"house_number","value":"781"},{"label":"road","value":"franklin ave"},{"label":"suburb","value":"crown heights"},{"label":"city_district","value":"brooklyn"},{"label":"city","value":"nyc"},{"label":"state","value":"ny"},{"label":"postcode","value":"11216"},{"label":"country","value":"usa"}]`,
               )
 
     testParse(t, "whole foods ny",
               []ParsedComponent {
-                {"whole foods", "house"},
-                {"ny", "state"},
+                {"house", "whole foods"},
+                {"state", "ny"},
               },
+              `[{"label":"house","value":"whole foods"},{"label":"state","value":"ny"}]`,
               )
 
     testParse(t, "1917/2 Pike Drive",
               []ParsedComponent {
-                {"1917 / 2", "house_number"},
-                {"pike drive", "road"},
+                {"house_number", "1917 / 2"},
+                {"road", "pike drive"},
               },
+              `[{"label":"house_number","value":"1917 / 2"},{"label":"road","value":"pike drive"}]`,
               )
-
 
     testParse(t, "3437 warwickshire rd,pa",
               []ParsedComponent {
-                {"3437", "house_number"},
-                {"warwickshire rd", "road"},
-                {"pa", "state"},
+                {"house_number", "3437"},
+                {"road", "warwickshire rd"},
+                {"state", "pa"},
               },
+              `[{"label":"house_number","value":"3437"},{"label":"road","value":"warwickshire rd"},{"label":"state","value":"pa"}]`,
               )
 
     testParse(t, "3437 warwickshire rd, pa",
               []ParsedComponent {
-                {"3437", "house_number"},
-                {"warwickshire rd", "road"},
-                {"pa", "state"},
+                {"house_number", "3437"},
+                {"road", "warwickshire rd"},
+                {"state", "pa"},
               },
+              `[{"label":"house_number","value":"3437"},{"label":"road","value":"warwickshire rd"},{"label":"state","value":"pa"}]`,
               )
 
     testParse(t, "3437 warwickshire rd pa",
               []ParsedComponent {
-                {"3437", "house_number"},
-                {"warwickshire rd", "road"},
-                {"pa", "state"},
+                {"house_number", "3437"},
+                {"road", "warwickshire rd"},
+                {"state", "pa"},
               },
+              `[{"label":"house_number","value":"3437"},{"label":"road","value":"warwickshire rd"},{"label":"state","value":"pa"}]`,
               )
-
 }


### PR DESCRIPTION
To parsed components. Reverse Label and Value to be more like the standard
key/value order, and let the JSON object labels be lowercase. Then just let
encoding/JSON do its thing. Include tests for each parsed address.

Resolves #2.
