### PR TITLE
Wrapping calls containing CGo sections in a mutex

### DIFF
--- a/expand/expand.go
+++ b/expand/expand.go
@@ -11,8 +11,11 @@ import "C"
 import (
     "unsafe"
     "log"
+    "sync"
     "unicode/utf8"
 )
+
+var mu sync.Mutex
 
 func init() {
     if (!bool(C.libpostal_setup()) || !bool(C.libpostal_setup_language_classifier())) {
@@ -92,6 +95,9 @@ func ExpandAddressOptions(address string, options ExpandOptions) []string {
     if !utf8.ValidString(address) {
         return nil
     }
+
+    mu.Lock()
+    defer mu.Unlock()
 
     cAddress := C.CString(address)
     defer C.free(unsafe.Pointer(cAddress))

--- a/expand/expand_test.go
+++ b/expand/expand_test.go
@@ -47,5 +47,5 @@ func TestMultilingualExpansions(t *testing.T) {
 
 
 func TestNonASCIIExpansions(t *testing.T) {
-    testExpansion(t, "Friedrichstraße 128, Berlin, Germany", "friedrich straße 128 berlin germany")
+    testExpansion(t, "Friedrichstraße 128, Berlin, Germany", "friedrich strasse 128 berlin germany")
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -9,9 +9,12 @@ import "C"
 
 import (
     "log"
+    "sync"
     "unsafe"
     "unicode/utf8"
 )
+
+var mu sync.Mutex
 
 func init() {
     if (!bool(C.libpostal_setup()) || !bool(C.libpostal_setup_parser())) {
@@ -44,12 +47,11 @@ func ParseAddressOptions(address string, options ParserOptions) []ParsedComponen
         return nil
     }
 
+    mu.Lock()
+    defer mu.Unlock()
 
     cAddress := C.CString(address)
     defer C.free(unsafe.Pointer(cAddress))
-
-    //var b *C.char
-    //ptr_size := unsafe.Sizeof(b)
 
     cOptions := C.libpostal_get_address_parser_default_options()
     if options.Language != "" {


### PR DESCRIPTION
While crossing the CGo boundary ensures that a goroutine is not swapped from one OS thread to another (via LockOSThread), it's still possible, under high concurrency, for multiple OS threads to access a CGo section at the same time. Adding mutexes to ensure that doesn't happen as libpostal is not thread-safe.