### PR TITLE
Made GetDefaultExpansionOptions public

### DIFF
--- a/expand/expand.go
+++ b/expand/expand.go
@@ -65,7 +65,7 @@ type ExpandOptions struct {
 
 var cDefaultOptions = C.libpostal_get_default_options()
 
-func getDefaultExpansionOptions() ExpandOptions {
+func GetDefaultExpansionOptions() ExpandOptions {
     return ExpandOptions{
         Languages: nil,
         AddressComponents: uint16(cDefaultOptions.address_components),
@@ -89,7 +89,7 @@ func getDefaultExpansionOptions() ExpandOptions {
     }
 }
 
-var libpostalDefaultOptions = getDefaultExpansionOptions()
+var libpostalDefaultOptions = GetDefaultExpansionOptions()
 
 func ExpandAddressOptions(address string, options ExpandOptions) []string {
     if !utf8.ValidString(address) {

--- a/expand/expand_test.go
+++ b/expand/expand_test.go
@@ -27,7 +27,7 @@ func testExpansionWithOptions(t *testing.T, address string, output string, optio
 func TestEnglishExpansions(t *testing.T) {
     testExpansion(t, "123 Main St", "123 main street")
 
-    englishOptions := getDefaultExpansionOptions()
+    englishOptions := GetDefaultExpansionOptions()
     englishOptions.Languages = []string{"en"}
 
     testExpansionWithOptions(t, "30 West Twenty-sixth St Fl No. 7", "30 west 26th street floor number 7", englishOptions) 
@@ -37,7 +37,7 @@ func TestEnglishExpansions(t *testing.T) {
 
 
 func TestMultilingualExpansions(t *testing.T) {
-    multilingualOptions := getDefaultExpansionOptions()
+    multilingualOptions := GetDefaultExpansionOptions()
     multilingualOptions.Languages = []string{"en", "fr", "de"}
 
     testExpansionWithOptions(t, "st", "sankt", multilingualOptions)


### PR DESCRIPTION
Please can you review this pull request that makes the GetDefaultExpansionOptions public.
This allows a consumer to get a copy of the default options then adjust the specifics for their use case.
e.g.
```
	options := expand.GetDefaultExpansionOptions()
	options.Lowercase = false
	output := expand.ExpandAddressOptions(input, options)
```
