### PR TITLE
Free expansion array after creating Go strings

### DIFF
--- a/expand/expand.go
+++ b/expand/expand.go
@@ -159,6 +159,7 @@ func ExpandAddressOptions(address string, options ExpandOptions) []string {
         expansions[i] = C.GoString(cExpansionsPtr[i])
     }
 
+    C.libpostal_expansion_array_destroy(cExpansions, cNumExpansions)
     return expansions
 }
 


### PR DESCRIPTION
Valgrind output without this:

```
==20497== 27 (24 direct, 3 indirect) bytes in 3 blocks are definitely lost in loss record 153 of 305
==20497==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==20497==    by 0x4E8626E: cstring_array_to_strings (string_utils.c:1038)
==20497==    by 0x4BAE7A: _cgo_2183ed9df389_Cfunc_libpostal_expand_address (cgo-gcc-prolog:72)
==20497==    by 0x45281F: runtime.asmcgocall (/usr/local/go/src/runtime/asm_amd64.s:624)
```