### PR TITLE
Added go.mod file to migrate to go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/openvenues/gopostal
+
+go 1.15


### PR DESCRIPTION
Currently I'm unable to import this in my project as this doesn't have go.mod file. This MR addresses it by adding go.mod file. Here are the steps that I followed:
1. Forked and cloned the repo.
2. ran go mod init github.com/openvenues/gopostal
3. go build ./... and go test ./... just to make sure all works.
4. Published the new release by adding a tag.
     git tag v1.0.0
     git push origin v1.0.0